### PR TITLE
[Enhancement] Add the s3 ducky logo in the header

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -20,6 +20,7 @@ import {
 } from "lucide-react"
 import { useTheme } from "next-themes"
 import DownloadCards from "@/components/DownloadCards"
+import Header from "@/components/Header"
 
 export default function S3DuckyLanding() {
   const { theme, setTheme } = useTheme()
@@ -111,46 +112,12 @@ export default function S3DuckyLanding() {
   return (
     <div className="min-h-screen bg-background theme-transition">
       {/* Header */}
-      <header className="border-b bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60 sticky top-0 z-50 theme-transition">
-        <div className="container mx-auto px-4 py-4 flex justify-between items-center">
-          <div className="flex items-center space-x-2">
-            <div className="w-8 h-8 bg-gradient-to-r from-blue-600 to-purple-600 rounded-lg flex items-center justify-center gradient-transition">
-              <span className="text-white font-bold text-sm">S3</span>
-            </div>
-            <span className="text-xl font-bold theme-transition">S3Ducky</span>
-          </div>
-          <div className="flex items-center space-x-4">
-            <Button
-              variant="ghost"
-              size="icon"
-              onClick={handleThemeToggle}
-              aria-label={`Switch to ${theme === "dark" ? "light" : "dark"} mode`}
-              className="relative theme-transition"
-            >
-              {theme === "dark" ? (
-                <Sun className="h-4 w-4 transition-all duration-300" />
-              ) : (
-                <Moon className="h-4 w-4 transition-all duration-300" />
-              )}
-              <span className="sr-only">Toggle theme</span>
-            </Button>
-            <Button variant="outline" asChild className="theme-transition bg-transparent">
-              <a href="https://github.com/yourusername/s3ducky" target="_blank" rel="noopener noreferrer">
-                <Github className="w-4 h-4 mr-2" />
-                GitHub
-              </a>
-            </Button>
-          </div>
-        </div>
-      </header>
+      <Header />
 
       {/* Hero Section */}
       <section className="py-20 px-4 theme-transition">
         <div className="container mx-auto text-center max-w-4xl">
           <div className="mb-8">
-            <div className="w-32 h-32 mx-auto mb-6 bg-gradient-to-br from-blue-500 via-purple-500 to-pink-500 rounded-2xl shadow-2xl flex items-center justify-center gradient-transition">
-              <span className="text-white font-bold text-4xl">S3</span>
-            </div>
           </div>
           <h1 className="text-5xl md:text-6xl font-bold mb-6 bg-gradient-to-r from-blue-600 via-purple-600 to-pink-600 bg-clip-text text-transparent gradient-transition">
             S3Ducky

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect } from "react"
 import { Button } from "@/components/ui/button"
 import { Github, Sun, Moon } from "lucide-react"
 import { useTheme } from "next-themes"
+import Image from "next/image"
 
 export default function Header() {
   const { theme, setTheme } = useTheme()
@@ -25,7 +26,7 @@ export default function Header() {
       <div className="container mx-auto px-4 py-4 flex justify-between items-center">
         <div className="flex items-center space-x-2">
           <div className="w-8 h-8 rounded-lg flex items-center justify-center overflow-hidden">
-            <img src="/S3DuckyLogo.png" alt="S3Ducky Logo" className="w-7 h-7 object-contain" />
+            <Image src="/S3DuckyLogo.png" alt="S3Ducky Logo" width={28} height={28} className="object-contain" />
           </div>
           <span className="text-xl font-bold theme-transition">S3Ducky</span>
         </div>

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -15,7 +15,8 @@ export default function Header() {
   }, [])
 
   const handleThemeToggle = () => {
-    const newTheme = theme === "dark" ? "light" : "dark"
+    const currentTheme = theme ?? "dark"
+    const newTheme = currentTheme === "dark" ? "light" : "dark"
     setTheme(newTheme)
   }
 

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -1,0 +1,57 @@
+"use client"
+
+import { useState, useEffect } from "react"
+import { Button } from "@/components/ui/button"
+import { Github, Sun, Moon } from "lucide-react"
+import { useTheme } from "next-themes"
+
+export default function Header() {
+  const { theme, setTheme } = useTheme()
+  const [mounted, setMounted] = useState(false)
+
+  useEffect(() => {
+    setMounted(true)
+  }, [])
+
+  const handleThemeToggle = () => {
+    const newTheme = theme === "dark" ? "light" : "dark"
+    setTheme(newTheme)
+  }
+
+  if (!mounted) return null
+
+  return (
+    <header className="border-b bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60 sticky top-0 z-50 theme-transition">
+      <div className="container mx-auto px-4 py-4 flex justify-between items-center">
+        <div className="flex items-center space-x-2">
+          <div className="w-8 h-8 rounded-lg flex items-center justify-center overflow-hidden">
+            <img src="/S3DuckyLogo.png" alt="S3Ducky Logo" className="w-7 h-7 object-contain" />
+          </div>
+          <span className="text-xl font-bold theme-transition">S3Ducky</span>
+        </div>
+        <div className="flex items-center space-x-4">
+          <Button
+            variant="ghost"
+            size="icon"
+            onClick={handleThemeToggle}
+            aria-label={`Switch to ${theme === "dark" ? "light" : "dark"} mode`}
+            className="relative theme-transition"
+          >
+            {theme === "dark" ? (
+              <Sun className="h-4 w-4 transition-all duration-300" />
+            ) : (
+              <Moon className="h-4 w-4 transition-all duration-300" />
+            )}
+            <span className="sr-only">Toggle theme</span>
+          </Button>
+          <Button variant="outline" asChild className="theme-transition bg-transparent">
+            <a href="https://github.com/yourusername/s3ducky" target="_blank" rel="noopener noreferrer">
+              <Github className="w-4 h-4 mr-2" />
+              GitHub
+            </a>
+          </Button>
+        </div>
+      </div>
+    </header>
+  )
+} 


### PR DESCRIPTION
Closes #10 

This PR adds a logo in the header and removes from the hero section.

## Summary by Sourcery

Extract the page header into a reusable component that includes the S3Ducky logo, theme toggle, and GitHub link, and remove the standalone logo from the hero section.

Enhancements:
- Add a new Header component with the S3Ducky logo image, site title, theme switcher, and GitHub button
- Replace the inline header in the landing page with the new Header component
- Remove the hero section’s standalone logo block