### PR TITLE
Fixed a bug related to the redirection of releases page in github

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -295,7 +295,7 @@ export default function S3DuckyLanding() {
               asChild
               className="hover:bg-gradient-to-r hover:from-blue-600 hover:to-purple-600 hover:text-white transition-all duration-300 bg-transparent theme-transition"
             >
-              <a href="https://github.com/yourusername/s3ducky/releases" target="_blank" rel="noopener noreferrer">
+              <a href="https://github.com/S3Ducky/frontend/releases" target="_blank" rel="noopener noreferrer">
                 <ExternalLink className="w-4 h-4 mr-2" />
                 View All Releases
               </a>


### PR DESCRIPTION
PR for resolving bug for github releases redirection

## Summary by Sourcery

Bug Fixes:
- Correct the GitHub releases page URL to point to the S3Ducky/frontend repository